### PR TITLE
Fix glide functionality

### DIFF
--- a/app/src/main/java/net/wetfish/wetfish/adapters/FilesAdapter.java
+++ b/app/src/main/java/net/wetfish/wetfish/adapters/FilesAdapter.java
@@ -195,10 +195,9 @@ public class FilesAdapter extends RecyclerView.Adapter<FilesAdapter.FileViewHold
                                         .load(editedFileStorageLink)
                                         .error(Glide.with(mContext)
                                                 .load(fileWetfishPath)
-//                                                .apply(RequestOptions.diskCacheStrategyOf(DiskCacheStrategy.RESOURCE))
                                                 .apply(RequestOptions.centerCropTransform()))
-                                        .apply(RequestOptions.placeholderOf(ContextCompat.getDrawable(mContext, R.drawable.glide_file_not_found_anywhere)))
                                         .apply(RequestOptions.centerCropTransform())
+                                        .apply(RequestOptions.placeholderOf(R.color.white))
                                         .transition(DrawableTransitionOptions.withCrossFade())
                                         .into(fileView);
                             } else {
@@ -207,8 +206,8 @@ public class FilesAdapter extends RecyclerView.Adapter<FilesAdapter.FileViewHold
                                         .error(Glide.with(mContext)
                                                 .load(fileWetfishPath)
                                                 .apply(RequestOptions.centerCropTransform()))
-                                        .apply(RequestOptions.placeholderOf(ContextCompat.getDrawable(mContext, R.drawable.glide_file_not_found_anywhere)))
                                         .apply(RequestOptions.centerCropTransform())
+                                        .apply(RequestOptions.placeholderOf(R.color.white))
                                         .transition(DrawableTransitionOptions.withCrossFade())
                                         .into(fileView);
                             }
@@ -220,8 +219,8 @@ public class FilesAdapter extends RecyclerView.Adapter<FilesAdapter.FileViewHold
                                             .load(fileWetfishPath)
 //                                            .apply(RequestOptions.diskCacheStrategyOf(DiskCacheStrategy.RESOURCE))
                                             .apply(RequestOptions.centerCropTransform()))
-                                    .apply(RequestOptions.placeholderOf(ContextCompat.getDrawable(mContext, R.drawable.glide_file_not_found_anywhere)))
                                     .apply(RequestOptions.centerCropTransform())
+                                    .apply(RequestOptions.placeholderOf(R.color.white))
                                     .transition(DrawableTransitionOptions.withCrossFade())
                                     .into(fileView);
                         }
@@ -230,8 +229,8 @@ public class FilesAdapter extends RecyclerView.Adapter<FilesAdapter.FileViewHold
                         // If the file is not representable by glide depict this to the user
                         Glide.with(mContext)
                                 .load(ContextCompat.getDrawable(mContext, R.drawable.glide_not_representable))
-                                .apply(RequestOptions.placeholderOf(ContextCompat.getDrawable(mContext, R.drawable.glide_not_representable)))
-                                .apply(RequestOptions.fitCenterTransform())
+                                .apply(RequestOptions.centerCropTransform())
+                                .apply(RequestOptions.placeholderOf(R.color.white))
                                 .transition(DrawableTransitionOptions.withCrossFade())
                                 .into(fileView);
                     }
@@ -246,9 +245,9 @@ public class FilesAdapter extends RecyclerView.Adapter<FilesAdapter.FileViewHold
                                         .load(editedFileStorageLink)
                                         .error(Glide.with(mContext)
                                                 .load(ContextCompat.getDrawable(mContext, R.drawable.glide_file_not_found_no_network))
-                                                .apply(RequestOptions.fitCenterTransform()))
-                                        .apply(RequestOptions.placeholderOf(ContextCompat.getDrawable(mContext, R.drawable.glide_file_not_found_no_network)))
+                                                .apply(RequestOptions.centerCropTransform()))
                                         .apply(RequestOptions.centerCropTransform())
+                                        .apply(RequestOptions.placeholderOf(R.color.white))
                                         .transition(DrawableTransitionOptions.withCrossFade())
                                         .into(fileView);
                             } else {
@@ -256,9 +255,9 @@ public class FilesAdapter extends RecyclerView.Adapter<FilesAdapter.FileViewHold
                                         .load(originalFileStorageLink)
                                         .error(Glide.with(mContext)
                                                 .load(ContextCompat.getDrawable(mContext, R.drawable.glide_file_not_found_no_network))
-                                                .apply(RequestOptions.fitCenterTransform()))
-                                        .apply(RequestOptions.placeholderOf(ContextCompat.getDrawable(mContext, R.drawable.glide_file_not_found_no_network)))
+                                                .apply(RequestOptions.centerCropTransform()))
                                         .apply(RequestOptions.centerCropTransform())
+                                        .apply(RequestOptions.placeholderOf(R.color.white))
                                         .transition(DrawableTransitionOptions.withCrossFade())
                                         .into(fileView);
                             }
@@ -270,9 +269,9 @@ public class FilesAdapter extends RecyclerView.Adapter<FilesAdapter.FileViewHold
                                     .load(originalFileStorageLink)
                                     .error(Glide.with(mContext)
                                             .load(ContextCompat.getDrawable(mContext, R.drawable.glide_file_not_found_no_network))
-                                            .apply(RequestOptions.fitCenterTransform()))
-                                    .apply(RequestOptions.placeholderOf(ContextCompat.getDrawable(mContext, R.drawable.glide_file_not_found_no_network)))
+                                            .apply(RequestOptions.centerCropTransform()))
                                     .apply(RequestOptions.centerCropTransform())
+                                    .apply(RequestOptions.placeholderOf(R.color.white))
                                     .transition(DrawableTransitionOptions.withCrossFade())
                                     .into(fileView);
                         }
@@ -281,8 +280,8 @@ public class FilesAdapter extends RecyclerView.Adapter<FilesAdapter.FileViewHold
                         // If the file is not representable by glide depict this to the user
                         Glide.with(mContext)
                                 .load(ContextCompat.getDrawable(mContext, R.drawable.glide_not_representable))
-                                .apply(RequestOptions.placeholderOf(ContextCompat.getDrawable(mContext, R.drawable.glide_not_representable)))
-                                .apply(RequestOptions.fitCenterTransform())
+                                .apply(RequestOptions.centerCropTransform())
+                                .apply(RequestOptions.placeholderOf(R.color.white))
                                 .transition(DrawableTransitionOptions.withCrossFade())
                                 .into(fileView);
                     }

--- a/app/src/main/java/net/wetfish/wetfish/adapters/FilesAdapter.java
+++ b/app/src/main/java/net/wetfish/wetfish/adapters/FilesAdapter.java
@@ -178,10 +178,12 @@ public class FilesAdapter extends RecyclerView.Adapter<FilesAdapter.FileViewHold
                 String fileType = fileCursor.getString(fileCursor.getColumnIndex(FileContract.FileColumns.COLUMN_FILE_TYPE_EXTENSION));
                 String mimeType = FileUtils.getMimeType(fileType, mContext);
 
+                boolean originalFilePresent = FileUtils.checkIfFileExists(originalFileStorageLink);
+                boolean editedFilePresent = FileUtils.checkIfFileExists(editedFileStorageLink);
+
                 // Network information
                 ConnectivityManager cm = (ConnectivityManager) mContext.getSystemService(Context.CONNECTIVITY_SERVICE);
                 NetworkInfo networkInfo = cm.getActiveNetworkInfo();
-
 
 
                 // Check to see if the network is connected and available
@@ -189,23 +191,35 @@ public class FilesAdapter extends RecyclerView.Adapter<FilesAdapter.FileViewHold
                     // Check to see if the file is representable by glide
                     if (FileUtils.representableByGlide(fileType)) {
                         // Image file loading for glide
-                        if(mimeType.equals(IMAGE_MIME_TYPE)) {
-                            // Load the edited file from the local storage if possible
-                            Glide.with(mContext)
-                                    .load(editedFileStorageLink)
-                                    .error(Glide.with(mContext)
-                                            .load(originalFileStorageLink)
-                                            .apply(RequestOptions.centerCropTransform()))
-                                    .error(Glide.with(mContext)
-                                            .load(fileWetfishPath)
-                                            .apply(RequestOptions.centerCropTransform()))
-                                    .error(Glide.with(mContext)
-                                            .load(ContextCompat.getDrawable(mContext, R.drawable.glide_file_not_found_anywhere))
-                                            .apply(RequestOptions.fitCenterTransform()))
-                                    .apply(RequestOptions.placeholderOf(new ColorDrawable(Color.DKGRAY)))
-                                    .apply(RequestOptions.centerCropTransform())
-                                    .transition(DrawableTransitionOptions.withCrossFade())
-                                    .into(fileView);
+                        if (mimeType.equals(IMAGE_MIME_TYPE)) {
+                            // Load the edited file from the local storage if possible, then move down the options
+                            if (editedFilePresent) {
+                                Glide.with(mContext)
+                                        .load(editedFileStorageLink)
+                                        .error(Glide.with(mContext)
+                                                .load(fileWetfishPath)
+                                                .apply(RequestOptions.centerCropTransform()))
+                                        .error(Glide.with(mContext)
+                                                .load(ContextCompat.getDrawable(mContext, R.drawable.glide_file_not_found_anywhere))
+                                                .apply(RequestOptions.fitCenterTransform()))
+                                        .apply(RequestOptions.placeholderOf(new ColorDrawable(Color.DKGRAY)))
+                                        .apply(RequestOptions.centerCropTransform())
+                                        .transition(DrawableTransitionOptions.withCrossFade())
+                                        .into(fileView);
+                            } else {
+                                Glide.with(mContext)
+                                        .load(originalFileStorageLink)
+                                        .error(Glide.with(mContext)
+                                                .load(fileWetfishPath)
+                                                .apply(RequestOptions.centerCropTransform()))
+                                        .error(Glide.with(mContext)
+                                                .load(ContextCompat.getDrawable(mContext, R.drawable.glide_file_not_found_anywhere))
+                                                .apply(RequestOptions.fitCenterTransform()))
+                                        .apply(RequestOptions.placeholderOf(new ColorDrawable(Color.DKGRAY)))
+                                        .apply(RequestOptions.centerCropTransform())
+                                        .transition(DrawableTransitionOptions.withCrossFade())
+                                        .into(fileView);
+                            }
                         } else {
                             // Video file loading for glide
                             Glide.with(mContext)
@@ -225,31 +239,40 @@ public class FilesAdapter extends RecyclerView.Adapter<FilesAdapter.FileViewHold
                     } else { // FileUtils.representableByGlide(mFileType) else
                         Log.d(LOG_TAG, "File is not representable by glide");
                         // If the file is not representable by glide depict this to the user
-                            Glide.with(mContext)
-                                    .load(ContextCompat.getDrawable(mContext, R.drawable.glide_not_representable))
-                                    .apply(RequestOptions.placeholderOf(new ColorDrawable(Color.DKGRAY)))
-                                    .apply(RequestOptions.fitCenterTransform())
-                                    .transition(DrawableTransitionOptions.withCrossFade())
-                                    .into(fileView);
+                        Glide.with(mContext)
+                                .load(ContextCompat.getDrawable(mContext, R.drawable.glide_not_representable))
+                                .apply(RequestOptions.placeholderOf(new ColorDrawable(Color.DKGRAY)))
+                                .apply(RequestOptions.fitCenterTransform())
+                                .transition(DrawableTransitionOptions.withCrossFade())
+                                .into(fileView);
                     }
                 } else { // mNetworkInfo != null && mNetworkInfo.isConnected() else
                     if (FileUtils.representableByGlide(fileType)) {
                         // Image file loading for glide
-                        if(mimeType.equals(IMAGE_MIME_TYPE)) {
-                            Log.d(LOG_TAG, "No network, edited file present");
-                            // Load the desired file storage link first, then
-                            Glide.with(mContext)
-                                    .load(editedFileStorageLink)
-                                    .error(Glide.with(mContext)
-                                            .load(originalFileStorageLink)
-                                            .apply(RequestOptions.centerCropTransform()))
-                                    .error(Glide.with(mContext)
-                                            .load(ContextCompat.getDrawable(mContext, R.drawable.glide_file_not_found_no_network))
-                                            .apply(RequestOptions.fitCenterTransform()))
-                                    .apply(RequestOptions.placeholderOf(new ColorDrawable(Color.DKGRAY)))
-                                    .apply(RequestOptions.centerCropTransform())
-                                    .transition(DrawableTransitionOptions.withCrossFade())
-                                    .into(fileView);
+                        if (mimeType.equals(IMAGE_MIME_TYPE)) {
+                            // Load the edited file from the local storage if possible, then move down the options
+                            if (editedFilePresent) {
+                                Log.d(LOG_TAG, "No network, edited file present");
+                                Glide.with(mContext)
+                                        .load(editedFileStorageLink)
+                                        .error(Glide.with(mContext)
+                                                .load(ContextCompat.getDrawable(mContext, R.drawable.glide_file_not_found_no_network))
+                                                .apply(RequestOptions.fitCenterTransform()))
+                                        .apply(RequestOptions.placeholderOf(new ColorDrawable(Color.DKGRAY)))
+                                        .apply(RequestOptions.centerCropTransform())
+                                        .transition(DrawableTransitionOptions.withCrossFade())
+                                        .into(fileView);
+                            } else {
+                                Glide.with(mContext)
+                                        .load(originalFileStorageLink)
+                                        .error(Glide.with(mContext)
+                                                .load(ContextCompat.getDrawable(mContext, R.drawable.glide_file_not_found_no_network))
+                                                .apply(RequestOptions.fitCenterTransform()))
+                                        .apply(RequestOptions.placeholderOf(new ColorDrawable(Color.DKGRAY)))
+                                        .apply(RequestOptions.centerCropTransform())
+                                        .transition(DrawableTransitionOptions.withCrossFade())
+                                        .into(fileView);
+                            }
                         } else {
                             // Video file loading for glide
                             Log.d(LOG_TAG, "No network, edited file present");

--- a/app/src/main/java/net/wetfish/wetfish/adapters/FilesAdapter.java
+++ b/app/src/main/java/net/wetfish/wetfish/adapters/FilesAdapter.java
@@ -2,8 +2,6 @@ package net.wetfish.wetfish.adapters;
 
 import android.content.Context;
 import android.database.Cursor;
-import android.graphics.Color;
-import android.graphics.drawable.ColorDrawable;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.support.v4.content.ContextCompat;
@@ -16,7 +14,6 @@ import android.widget.ImageView;
 import android.widget.ListView;
 
 import com.bumptech.glide.Glide;
-import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions;
 import com.bumptech.glide.request.RequestOptions;
 
@@ -198,11 +195,9 @@ public class FilesAdapter extends RecyclerView.Adapter<FilesAdapter.FileViewHold
                                         .load(editedFileStorageLink)
                                         .error(Glide.with(mContext)
                                                 .load(fileWetfishPath)
+//                                                .apply(RequestOptions.diskCacheStrategyOf(DiskCacheStrategy.RESOURCE))
                                                 .apply(RequestOptions.centerCropTransform()))
-                                        .error(Glide.with(mContext)
-                                                .load(ContextCompat.getDrawable(mContext, R.drawable.glide_file_not_found_anywhere))
-                                                .apply(RequestOptions.fitCenterTransform()))
-                                        .apply(RequestOptions.placeholderOf(new ColorDrawable(Color.DKGRAY)))
+                                        .apply(RequestOptions.placeholderOf(ContextCompat.getDrawable(mContext, R.drawable.glide_file_not_found_anywhere)))
                                         .apply(RequestOptions.centerCropTransform())
                                         .transition(DrawableTransitionOptions.withCrossFade())
                                         .into(fileView);
@@ -212,10 +207,7 @@ public class FilesAdapter extends RecyclerView.Adapter<FilesAdapter.FileViewHold
                                         .error(Glide.with(mContext)
                                                 .load(fileWetfishPath)
                                                 .apply(RequestOptions.centerCropTransform()))
-                                        .error(Glide.with(mContext)
-                                                .load(ContextCompat.getDrawable(mContext, R.drawable.glide_file_not_found_anywhere))
-                                                .apply(RequestOptions.fitCenterTransform()))
-                                        .apply(RequestOptions.placeholderOf(new ColorDrawable(Color.DKGRAY)))
+                                        .apply(RequestOptions.placeholderOf(ContextCompat.getDrawable(mContext, R.drawable.glide_file_not_found_anywhere)))
                                         .apply(RequestOptions.centerCropTransform())
                                         .transition(DrawableTransitionOptions.withCrossFade())
                                         .into(fileView);
@@ -226,12 +218,9 @@ public class FilesAdapter extends RecyclerView.Adapter<FilesAdapter.FileViewHold
                                     .load(originalFileStorageLink)
                                     .error(Glide.with(mContext)
                                             .load(fileWetfishPath)
-                                            .apply(RequestOptions.diskCacheStrategyOf(DiskCacheStrategy.RESOURCE))
+//                                            .apply(RequestOptions.diskCacheStrategyOf(DiskCacheStrategy.RESOURCE))
                                             .apply(RequestOptions.centerCropTransform()))
-                                    .error(Glide.with(mContext)
-                                            .load(ContextCompat.getDrawable(mContext, R.drawable.glide_file_not_found_anywhere))
-                                            .apply(RequestOptions.centerCropTransform()))
-                                    .apply(RequestOptions.placeholderOf(new ColorDrawable(Color.DKGRAY)))
+                                    .apply(RequestOptions.placeholderOf(ContextCompat.getDrawable(mContext, R.drawable.glide_file_not_found_anywhere)))
                                     .apply(RequestOptions.centerCropTransform())
                                     .transition(DrawableTransitionOptions.withCrossFade())
                                     .into(fileView);
@@ -241,7 +230,7 @@ public class FilesAdapter extends RecyclerView.Adapter<FilesAdapter.FileViewHold
                         // If the file is not representable by glide depict this to the user
                         Glide.with(mContext)
                                 .load(ContextCompat.getDrawable(mContext, R.drawable.glide_not_representable))
-                                .apply(RequestOptions.placeholderOf(new ColorDrawable(Color.DKGRAY)))
+                                .apply(RequestOptions.placeholderOf(ContextCompat.getDrawable(mContext, R.drawable.glide_not_representable)))
                                 .apply(RequestOptions.fitCenterTransform())
                                 .transition(DrawableTransitionOptions.withCrossFade())
                                 .into(fileView);
@@ -258,7 +247,7 @@ public class FilesAdapter extends RecyclerView.Adapter<FilesAdapter.FileViewHold
                                         .error(Glide.with(mContext)
                                                 .load(ContextCompat.getDrawable(mContext, R.drawable.glide_file_not_found_no_network))
                                                 .apply(RequestOptions.fitCenterTransform()))
-                                        .apply(RequestOptions.placeholderOf(new ColorDrawable(Color.DKGRAY)))
+                                        .apply(RequestOptions.placeholderOf(ContextCompat.getDrawable(mContext, R.drawable.glide_file_not_found_no_network)))
                                         .apply(RequestOptions.centerCropTransform())
                                         .transition(DrawableTransitionOptions.withCrossFade())
                                         .into(fileView);
@@ -268,7 +257,7 @@ public class FilesAdapter extends RecyclerView.Adapter<FilesAdapter.FileViewHold
                                         .error(Glide.with(mContext)
                                                 .load(ContextCompat.getDrawable(mContext, R.drawable.glide_file_not_found_no_network))
                                                 .apply(RequestOptions.fitCenterTransform()))
-                                        .apply(RequestOptions.placeholderOf(new ColorDrawable(Color.DKGRAY)))
+                                        .apply(RequestOptions.placeholderOf(ContextCompat.getDrawable(mContext, R.drawable.glide_file_not_found_no_network)))
                                         .apply(RequestOptions.centerCropTransform())
                                         .transition(DrawableTransitionOptions.withCrossFade())
                                         .into(fileView);
@@ -282,7 +271,7 @@ public class FilesAdapter extends RecyclerView.Adapter<FilesAdapter.FileViewHold
                                     .error(Glide.with(mContext)
                                             .load(ContextCompat.getDrawable(mContext, R.drawable.glide_file_not_found_no_network))
                                             .apply(RequestOptions.fitCenterTransform()))
-                                    .apply(RequestOptions.placeholderOf(new ColorDrawable(Color.DKGRAY)))
+                                    .apply(RequestOptions.placeholderOf(ContextCompat.getDrawable(mContext, R.drawable.glide_file_not_found_no_network)))
                                     .apply(RequestOptions.centerCropTransform())
                                     .transition(DrawableTransitionOptions.withCrossFade())
                                     .into(fileView);
@@ -292,7 +281,7 @@ public class FilesAdapter extends RecyclerView.Adapter<FilesAdapter.FileViewHold
                         // If the file is not representable by glide depict this to the user
                         Glide.with(mContext)
                                 .load(ContextCompat.getDrawable(mContext, R.drawable.glide_not_representable))
-                                .apply(RequestOptions.placeholderOf(new ColorDrawable(Color.DKGRAY)))
+                                .apply(RequestOptions.placeholderOf(ContextCompat.getDrawable(mContext, R.drawable.glide_not_representable)))
                                 .apply(RequestOptions.fitCenterTransform())
                                 .transition(DrawableTransitionOptions.withCrossFade())
                                 .into(fileView);

--- a/app/src/main/java/net/wetfish/wetfish/ui/GalleryCollectionActivity.java
+++ b/app/src/main/java/net/wetfish/wetfish/ui/GalleryCollectionActivity.java
@@ -35,6 +35,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import com.bumptech.glide.Glide;
+import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions;
 import com.bumptech.glide.request.RequestOptions;
 import com.github.clans.fab.FloatingActionButton;
@@ -267,8 +268,6 @@ public class GalleryCollectionActivity extends AppCompatActivity {
         private Uri mUri;
         // FileInfo object that holds all data
         private FileInfo mFileInfo;
-        // String to hold the desired storage link to use
-        private String mDesiredFileStorageLink;
         // String to hold the original file storage link
         private String mOriginalFileStorageLink;
         // String to hold the edited file storage link
@@ -432,6 +431,8 @@ public class GalleryCollectionActivity extends AppCompatActivity {
             if (mNetworkInfo != null && mNetworkInfo.isConnected()) {
                 // Check to see if the file is representable by glide
                 if (FileUtils.representableByGlide(mFileType)) {
+                    // Image file loading for glide
+                    if(mimeType.equals(getString(R.string.image_mime_type))) {
                         // Load the edited file from the local storage if possible, then move down the options
                         Glide.with(this)
                                 .load(mEditedFileStorageLink)
@@ -448,6 +449,22 @@ public class GalleryCollectionActivity extends AppCompatActivity {
                                 .apply(RequestOptions.fitCenterTransform())
                                 .transition(DrawableTransitionOptions.withCrossFade())
                                 .into(mFileView);
+                    } else {
+                        // Video file loading for glide
+                        Glide.with(this)
+                                .load(mOriginalFileStorageLink)
+                                .error(Glide.with(this)
+                                        .load(mWetfishFileStorageLink)
+                                        .apply(RequestOptions.diskCacheStrategyOf(DiskCacheStrategy.RESOURCE))
+                                        .apply(RequestOptions.fitCenterTransform()))
+                                .error(Glide.with(this)
+                                        .load(R.drawable.glide_file_not_found_anywhere)
+                                        .apply(RequestOptions.fitCenterTransform()))
+                                .apply(RequestOptions.placeholderOf(new ColorDrawable(Color.DKGRAY)))
+                                .apply(RequestOptions.fitCenterTransform())
+                                .transition(DrawableTransitionOptions.withCrossFade())
+                                .into(mFileView);
+                    }
                 } else { // FileUtils.representableByGlide(mFileType) else
                     Log.d(LOG_TAG, "File is not representable by glide");
                     // If the file is not representable by glide depict this to the user
@@ -460,6 +477,8 @@ public class GalleryCollectionActivity extends AppCompatActivity {
                 }
             } else { // mNetworkInfo != null && mNetworkInfo.isConnected() else
                 if (FileUtils.representableByGlide(mFileType)) {
+                    // Image file loading for glide
+                    if(mimeType.equals(getString(R.string.image_mime_type))) {
                         Log.d(LOG_TAG, "No network, edited file present");
                         // Load the desired file storage link first, then
                         Glide.with(this)
@@ -474,6 +493,19 @@ public class GalleryCollectionActivity extends AppCompatActivity {
                                 .apply(RequestOptions.fitCenterTransform())
                                 .transition(DrawableTransitionOptions.withCrossFade())
                                 .into(mFileView);
+                    } else {
+                        Log.d(LOG_TAG, "No network, edited file present");
+                        // Load the desired file storage link first, then
+                        Glide.with(this)
+                                .load(mOriginalFileStorageLink)
+                                .error(Glide.with(this)
+                                        .load(R.drawable.glide_file_not_found_no_network)
+                                        .apply(RequestOptions.fitCenterTransform()))
+                                .apply(RequestOptions.placeholderOf(new ColorDrawable(Color.DKGRAY)))
+                                .apply(RequestOptions.fitCenterTransform())
+                                .transition(DrawableTransitionOptions.withCrossFade())
+                                .into(mFileView);
+                    }
                 } else { // FileUtils.representableByGlide(mFileType) else
                     Log.d(LOG_TAG, "File is not representable by glide");
                     // If the file is not representable by glide depict this to the user
@@ -491,6 +523,7 @@ public class GalleryCollectionActivity extends AppCompatActivity {
             mFileDescriptionTextView.setText(fileInfo.getFileDescription());
 
         }
+
 
         private void setupOnInteractionListeners(boolean deletionLinkPresent) {
 

--- a/app/src/main/java/net/wetfish/wetfish/ui/GalleryCollectionActivity.java
+++ b/app/src/main/java/net/wetfish/wetfish/ui/GalleryCollectionActivity.java
@@ -35,7 +35,6 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import com.bumptech.glide.Glide;
-import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions;
 import com.bumptech.glide.request.RequestOptions;
 import com.github.clans.fab.FloatingActionButton;
@@ -439,10 +438,7 @@ public class GalleryCollectionActivity extends AppCompatActivity {
                                     .error(Glide.with(this)
                                             .load(mWetfishFileStorageLink)
                                             .apply(RequestOptions.fitCenterTransform()))
-                                    .error(Glide.with(this)
-                                            .load(R.drawable.glide_file_not_found_anywhere)
-                                            .apply(RequestOptions.fitCenterTransform()))
-                                    .apply(RequestOptions.placeholderOf(new ColorDrawable(Color.DKGRAY)))
+                                    .apply(RequestOptions.placeholderOf(R.drawable.glide_file_not_found_anywhere))
                                     .apply(RequestOptions.fitCenterTransform())
                                     .transition(DrawableTransitionOptions.withCrossFade())
                                     .into(mFileView);
@@ -452,10 +448,7 @@ public class GalleryCollectionActivity extends AppCompatActivity {
                                     .error(Glide.with(this)
                                             .load(mWetfishFileStorageLink)
                                             .apply(RequestOptions.fitCenterTransform()))
-                                    .error(Glide.with(this)
-                                            .load(R.drawable.glide_file_not_found_anywhere)
-                                            .apply(RequestOptions.fitCenterTransform()))
-                                    .apply(RequestOptions.placeholderOf(new ColorDrawable(Color.DKGRAY)))
+                                    .apply(RequestOptions.placeholderOf(R.drawable.glide_file_not_found_anywhere))
                                     .apply(RequestOptions.fitCenterTransform())
                                     .transition(DrawableTransitionOptions.withCrossFade())
                                     .into(mFileView);
@@ -466,12 +459,9 @@ public class GalleryCollectionActivity extends AppCompatActivity {
                                 .load(mOriginalFileStorageLink)
                                 .error(Glide.with(this)
                                         .load(mWetfishFileStorageLink)
-                                        .apply(RequestOptions.diskCacheStrategyOf(DiskCacheStrategy.RESOURCE))
+//                                        .apply(RequestOptions.diskCacheStrategyOf(DiskCacheStrategy.RESOURCE))
                                         .apply(RequestOptions.fitCenterTransform()))
-                                .error(Glide.with(this)
-                                        .load(R.drawable.glide_file_not_found_anywhere)
-                                        .apply(RequestOptions.fitCenterTransform()))
-                                .apply(RequestOptions.placeholderOf(new ColorDrawable(Color.DKGRAY)))
+                                .apply(RequestOptions.placeholderOf(R.drawable.glide_file_not_found_anywhere))
                                 .apply(RequestOptions.fitCenterTransform())
                                 .transition(DrawableTransitionOptions.withCrossFade())
                                 .into(mFileView);
@@ -498,7 +488,7 @@ public class GalleryCollectionActivity extends AppCompatActivity {
                                     .error(Glide.with(this)
                                             .load(R.drawable.glide_file_not_found_no_network)
                                             .apply(RequestOptions.fitCenterTransform()))
-                                    .apply(RequestOptions.placeholderOf(new ColorDrawable(Color.DKGRAY)))
+                                    .apply(RequestOptions.placeholderOf(R.drawable.glide_file_not_found_no_network))
                                     .apply(RequestOptions.fitCenterTransform())
                                     .transition(DrawableTransitionOptions.withCrossFade())
                                     .into(mFileView);
@@ -508,7 +498,7 @@ public class GalleryCollectionActivity extends AppCompatActivity {
                                     .error(Glide.with(this)
                                             .load(R.drawable.glide_file_not_found_no_network)
                                             .apply(RequestOptions.fitCenterTransform()))
-                                    .apply(RequestOptions.placeholderOf(new ColorDrawable(Color.DKGRAY)))
+                                    .apply(RequestOptions.placeholderOf(R.drawable.glide_file_not_found_no_network))
                                     .apply(RequestOptions.fitCenterTransform())
                                     .transition(DrawableTransitionOptions.withCrossFade())
                                     .into(mFileView);
@@ -521,7 +511,7 @@ public class GalleryCollectionActivity extends AppCompatActivity {
                                 .error(Glide.with(this)
                                         .load(R.drawable.glide_file_not_found_no_network)
                                         .apply(RequestOptions.fitCenterTransform()))
-                                .apply(RequestOptions.placeholderOf(new ColorDrawable(Color.DKGRAY)))
+                                .apply(RequestOptions.placeholderOf(R.drawable.glide_file_not_found_no_network))
                                 .apply(RequestOptions.fitCenterTransform())
                                 .transition(DrawableTransitionOptions.withCrossFade())
                                 .into(mFileView);
@@ -531,7 +521,7 @@ public class GalleryCollectionActivity extends AppCompatActivity {
                     // If the file is not representable by glide depict this to the user
                     Glide.with(this)
                             .load(R.drawable.glide_not_representable)
-                            .apply(RequestOptions.placeholderOf(new ColorDrawable(Color.DKGRAY)))
+                            .apply(RequestOptions.placeholderOf(R.drawable.glide_not_representable))
                             .apply(RequestOptions.fitCenterTransform())
                             .transition(DrawableTransitionOptions.withCrossFade())
                             .into(mFileView);

--- a/app/src/main/res/layout/file_item.xml
+++ b/app/src/main/res/layout/file_item.xml
@@ -9,6 +9,7 @@
         android:layout_height="120dp"
         android:layout_gravity="center_horizontal"
         android:layout_margin="8dp"
+        android:adjustViewBounds="true"
         android:elevation="2dp"
         card_view:cardCornerRadius="3dp"
         card_view:cardMaxElevation="4dp">


### PR DESCRIPTION
This pull request will further fix the image loading solution used for the app. Nesting .error statements to go down a series of load options if one isn't found proved to not work with Glide's library so multiple glide loading statements that take into consideration the files not present to require only one .error. 

Using a placeholder that has a specific resolution will cause the file thumbnails loaded to share the placeholder's resolution. Because of this, Glide will crop the image short of the view's height and leave white bars on the top and bottom of the view. A white background has been used instead so that glide can fill the view appropriately, and should something go wrong with loading the file thumbnail or the backup thumbnail, will load a white background.