### PR TITLE
Alpha v1.8.0 Releasae

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "net.wetfish.wetfish"
         minSdkVersion 19
         targetSdkVersion 27
-        versionCode 17
-        versionName "1.8.0"
+        versionCode 18
+        versionName "1.9.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/net/wetfish/wetfish/ui/GalleryCollectionActivity.java
+++ b/app/src/main/java/net/wetfish/wetfish/ui/GalleryCollectionActivity.java
@@ -691,10 +691,10 @@ public class GalleryCollectionActivity extends AppCompatActivity {
 
                     // Check to see if the clipboard data link equals the database stored link
                     if (clipboardClipData.equals(mFileInfo.getFileWetfishStorageLink())) {
-                        Snackbar.make(mRootView.findViewById(android.R.id.content), R.string.sb_url_clipboard_success,
+                        Snackbar.make(mIncludeLayout, R.string.sb_url_clipboard_success,
                                 Snackbar.LENGTH_SHORT).show();
                     } else {
-                        Snackbar.make(mRootView.findViewById(android.R.id.content), R.string.sb_url_clipboard_failure,
+                        Snackbar.make(mIncludeLayout, R.string.sb_url_clipboard_failure,
                                 Snackbar.LENGTH_SHORT).show();
                     }
 
@@ -724,6 +724,7 @@ public class GalleryCollectionActivity extends AppCompatActivity {
                     }
                 });
 
+                //TODO: This is placeholder code that'll be implemented properly when Wetfish offers a delete URL
                 mCopyFileDeleteURLFAB.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View view) {
@@ -735,7 +736,7 @@ public class GalleryCollectionActivity extends AppCompatActivity {
                         clipboard.setPrimaryClip(ClipData.newPlainText("Uploaded File Url", mFileInfo.getFileWetfishDeletionLink()));
 
                         if (clipboard.getPrimaryClip().equals(mFileInfo.getFileWetfishDeletionLink())) {
-                            Snackbar.make(mRootView.findViewById(android.R.id.content), R.string.sb_url_clipboard_success,
+                            Snackbar.make(mIncludeLayout, R.string.sb_url_clipboard_success,
                                     Snackbar.LENGTH_LONG);
                         }
                     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -148,23 +148,15 @@
     <string name="pref_appVersionSummary_key">pref_appVersionSummary_key</string>
     <string name="pref_appVersionSummary_title">Version Summary</string>
     <string name="pref_appVersionSummary">
-    <b>Gallery Activity</b>\n
-    - Card View Spacing now takes more space \n\n
-
-    <b>Gallery Collection Activity</b>\n
-    - Fix crashing when various files aren\'t present while moving through items\n
-    - PNG pictures of appropriate file states\n
-    - File clicking will now redirect the user to Wetfish if not on the file system\n
-    - File clicking will now appropriately open up the correct image\n\n
+    <b>EXIF UPDATE</b>\n
 
     <b>Upload Page</b>\n
-    - An alert dialog will now pop up when moving back screens\n
-    - Video Uploading now has one tab\n
-    - View alignment fixed\n
-    - Loading Tab on devices greater than v24\n\n
+    - Change upload delay from three seconds to two seconds. \n
+    - Change how the EXIF tab works, allowing users to select EXIF settings to remove during the upload process and save these selections as persistent settings automatically upon change. \n
+    - Apply the current Wetfish version to the User Comment portion of the EXIF for Wetfish server’s new policy. \n
+    - Make the upload process produce an AlertDialog should EXIF editing fail during the process. \n
+    - Make the upload process cancelable throughout the entire process. \n
 
-    <b>Misc.</b>\n
-    - Fix for crashes on bitmap rescaling\n
     </string>
     <string name="pref_appVersionSummary_prompt">Click here for Wetfish version details</string>
     <string name="dialog_acknowledged">Okay</string>


### PR DESCRIPTION
Change upload delay from three seconds to two seconds.

Change how the EXIF tab works, allowing users to select EXIF settings to remove during the upload process and save these selections as persistent settings automatically upon change.

Apply the current Wetfish version to the User Comment portion of the EXIF for Wetfish server’s new policy.

Make the upload process produce an AlertDialog should EXIF editing fail during the process.

Make the upload process cancelable throughout the entire process of the upload.

Refactor how & when EXIF data is accessed, removed, and edited.

Refactor how & when new images are created during the upload process for edited EXIF.

Refactor how files were checked during the upload process for a more streamlined, efficient method.